### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/CAE/Segmentation/paddleseg/core/train.py
+++ b/CAE/Segmentation/paddleseg/core/train.py
@@ -255,7 +255,7 @@ def train(model,
             train_profiler.add_profiler_step(profiler_options)
 
             model.clear_gradients()
-            avg_loss += loss.numpy()[0]
+            avg_loss += float(loss)
             if not avg_loss_list:
                 avg_loss_list = [l.numpy() for l in loss_list]
             else:

--- a/CAE/Segmentation/paddleseg/models/losses/ohem_cross_entropy_loss.py
+++ b/CAE/Segmentation/paddleseg/models/losses/ohem_cross_entropy_loss.py
@@ -77,7 +77,7 @@ class OhemCrossEntropyLoss(nn.Layer):
             if self.min_kept > 0:
                 index = prob.argsort()
                 threshold_index = index[min(len(index), self.min_kept) - 1]
-                threshold_index = int(threshold_index.numpy()[0])
+                threshold_index = int(threshold_index)
                 if prob[threshold_index] > self.thresh:
                     threshold = prob[threshold_index]
                 kept_mask = (prob < threshold).astype('int64')

--- a/CAE/Segmentation/paddleseg/models/losses/ohem_edge_attention_loss.py
+++ b/CAE/Segmentation/paddleseg/models/losses/ohem_edge_attention_loss.py
@@ -93,7 +93,7 @@ class OhemEdgeAttentionLoss(nn.Layer):
             if self.min_kept > 0:
                 index = prob.argsort()
                 threshold_index = index[min(len(index), self.min_kept) - 1]
-                threshold_index = int(threshold_index.numpy()[0])
+                threshold_index = int(threshold_index)
                 if prob[threshold_index] > self.thresh:
                     threshold = prob[threshold_index]
                 kept_mask = (prob < threshold).astype('int64')

--- a/StrucTexT/v1/model/encoder.py
+++ b/StrucTexT/v1/model/encoder.py
@@ -236,7 +236,7 @@ class Encoder(ErnieModel):
 
         embedded = token_embeded + pos_embeded + sent_embeded + line_embeded + layout_embeded
 
-        nan_count = int(embedded.isnan().cast('int32').sum().numpy()[0])
+        nan_count = int(embedded.isnan().cast('int32').sum())
         if nan_count > 0:
             embedded = P.where(embedded.is_nan(), P.zeros_like(embedded, 'float32'), embedded)
             logging.error('there are nan in embedded input', nan_count)

--- a/StrucTexT/v2/src/tasks/end2end_ie/model.py
+++ b/StrucTexT/v2/src/tasks/end2end_ie/model.py
@@ -540,6 +540,6 @@ class Model(Encoder):
         probs = probs.topk(1, axis=-1, largest=True, sorted=True)[0].reshape([-1])
         preds_index = preds_index.reshape([-1])
         word = self.label_converter.decode(preds_index)
-        prob = 0.0 if len(word) == 0 else probs[:len(word)].mean().numpy()[0]
+        prob = 0.0 if len(word) == 0 else float(probs[:len(word)].mean())
 
         return word, prob

--- a/StrucTexT/v2/src/tasks/end2end_ie_xfund/model.py
+++ b/StrucTexT/v2/src/tasks/end2end_ie_xfund/model.py
@@ -526,6 +526,6 @@ class Model(Encoder):
         probs = probs.topk(1, axis=-1, largest=True, sorted=True)[0].reshape([-1])
         preds_index = preds_index.reshape([-1])
         word = self.label_converter.decode(preds_index)
-        prob = 0.0 if len(word) == 0 else probs[:len(word)].mean().numpy()[0]
+        prob = 0.0 if len(word) == 0 else float(probs[:len(word)].mean())
 
         return word, prob

--- a/StrucTexT/v2/src/tasks/end2end_ocr/model.py
+++ b/StrucTexT/v2/src/tasks/end2end_ocr/model.py
@@ -343,6 +343,6 @@ class Model(Encoder):
         probs = probs.topk(1, axis=-1, largest=True, sorted=True)[0].reshape([-1])
         preds_index = preds_index.reshape([-1])
         word = self.label_converter.decode(preds_index)
-        prob = 0.0 if len(word) == 0 else probs[:len(word)].mean().numpy()[0]
+        prob = 0.0 if len(word) == 0 else float(probs[:len(word)].mean())
 
         return word, prob


### PR DESCRIPTION
loss正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在进行升级为0D后，loss.numpy()[0] 的写法不再使用，将其改变为 float(loss) 的写法，在升级前(shape为[1])、升级后(shape为[])下都同样适用，兼容改法。