### PR TITLE
adapt CAE to xpu

### DIFF
--- a/CAE/packages/engine_for_finetuning.py
+++ b/CAE/packages/engine_for_finetuning.py
@@ -106,7 +106,10 @@ def train_one_epoch(model: nn.Layer,
                     model_ema.update(model)
             loss_scale_value = loss_scaler.state_dict()["scale"].item()
 
-        paddle.device.cuda.synchronize()
+        if paddle.device.is_compiled_with_cuda():
+            paddle.device.cuda.synchronize()
+        elif paddle.device.is_compiled_with_xpu():
+            paddle.device.xpu.synchronize()
 
         if mixup_fn is None:
             class_acc = (output.argmax(-1) == targets).astype(paddle.float32).mean().item()

--- a/CAE/packages/engine_for_pretraining.py
+++ b/CAE/packages/engine_for_pretraining.py
@@ -144,7 +144,10 @@ def train_one_epoch(model: nn.Layer, d_vae: nn.Layer,
                                 parameters=model.parameters(), create_graph=is_second_order, use_amp=args.amp)
         loss_scale_value = loss_scaler.state_dict().get("scale").item()
 
-        paddle.device.cuda.synchronize()
+        if paddle.device.is_compiled_with_cuda():
+            paddle.device.cuda.synchronize()
+        elif paddle.device.is_compiled_with_xpu():
+            paddle.device.xpu.synchronize()
 
         if args.target_mode == 'clusterID':
             mlm_acc = (outputs.argmax(-1) == labels).astype(paddle.float32).mean().item()


### PR DESCRIPTION
1. add paddle.device.xpu.synchronize()
2. 由于paddle2.4版本之后主框架adamw中缺少了_append_decoupled_weight_decay，为保证与paddle2.3版本精度对齐，在CAE/utils/adamw.py中添加_append_decoupled_weight_decay方法